### PR TITLE
Add toggle for dark mode

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -19,6 +19,11 @@ article p.admonition-title {
   color: black;
 }
 
+[data-md-color-scheme="slate"] .md-typeset h1,
+[data-md-color-scheme="slate"] .md-typeset h2 {
+  color: white;
+}
+
 s {
   color: #900;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,8 +74,19 @@ theme:
     - content.code.annotate
     - content.code.copy
   palette:
-    primary: custom
-    accent: custom
+    - scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
   shortcuts:
     previous: 72 #h
     next: 76 #l


### PR DESCRIPTION
The Material for MkDocs theme has a built-in dark mode based on the documentation found [here](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/). This adds a toggle button to switch between the light and dark modes.

I've tested on a couple of our pages and mostly seems ok in the dark mode. Should not affect the original light mode that we have been using.